### PR TITLE
Name the app :dotenv, not :dotenv_elixir

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule DotenvElixir.Mixfile do
   use Mix.Project
 
   def project do
-    [ app: :dotenv_elixir,
+    [ app: :dotenv,
       version: "0.0.2",
       elixir: "~> 0.14.3",
       deps: deps,


### PR DESCRIPTION
The name of the repo is sufficient to identify it as an Elixir project, but you should be able to use it as `:dotenv` in your mix.exs
