### PR TITLE
Add support for the export syntax

### DIFF
--- a/lib/dotenv.ex
+++ b/lib/dotenv.ex
@@ -26,7 +26,21 @@ defmodule Dotenv do
     Dotenv.Supervisor.start_link(env_path)
   end
 
-  @pattern ~r/^\s*(\w+)\s*[:=]\s*(\S+)\s*$/m
+  @pattern ~r/
+    ^
+    (?:export\s+)?    # optional export
+    ([\w\.]+)         # key
+    (?:\s*=\s*|:\s+?) # separator
+    (                 # optional value begin
+      '(?:\'|[^'])*'  #   single quoted value
+      |               #   or
+      "(?:\"|[^"])*"  #   double quoted value
+      |               #   or
+      [^#\n]+         #   unquoted value
+    )?                # value end
+    (?:\s*\#.*)?      # optional comment
+    $
+    /xm
 
   ##############################################################################
   # Server API

--- a/test/fixture/proj1/.env
+++ b/test/fixture/proj1/.env
@@ -1,4 +1,4 @@
-FOO_BAR=1234
+export FOO_BAR=1234
 BAZ = 5678
 # this is a comment
 BUZ: 9999


### PR DESCRIPTION
I just stole the regular expressions from
https://github.com/bkeepers/dotenv/blob/master/lib/dotenv/parser.rb#L12-L26
