### PR TITLE
ignore whitespace separating value and inline comment

### DIFF
--- a/lib/dotenv.ex
+++ b/lib/dotenv.ex
@@ -36,7 +36,7 @@ defmodule Dotenv do
       |               #   or
       "(?:\"|[^"])*"  #   double quoted value
       |               #   or
-      [^#\n]+         #   unquoted value
+      [^#\n]+?        #   unquoted value
     )?                # value end
     (?:\s*\#.*)?      # optional comment
     $

--- a/test/dotenv_test.exs
+++ b/test/dotenv_test.exs
@@ -12,15 +12,17 @@ defmodule DotenvTest do
     assert env["FOO_BAR"] == "1234"
     assert env["BAZ"] == "5678"
     assert env["BUZ"] == "9999"
+    assert env["QUX"] == "0000"
   end
 
   test "finding the dotenv from a subdir" do
-    File.cd!(Path.join(proj1_dir, "subdir"))
+    File.cd! Path.join(proj1_dir, "subdir")
     env = Dotenv.load
     assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir)
     assert env["FOO_BAR"] == "1234"
     assert env["BAZ"] == "5678"
     assert env["BUZ"] == "9999"
+    assert env["QUX"] == "0000"
   end
 
   test "loading into system environment" do
@@ -30,6 +32,7 @@ defmodule DotenvTest do
     assert get_env("FOO_BAR") == "1234"
     assert get_env("BAZ")     == "5678"
     assert get_env("BUZ")     == "9999"
+    assert get_env("QUX")     == "0000"
   end
 
   test "falling back to system environment" do

--- a/test/fixture/proj1/.env
+++ b/test/fixture/proj1/.env
@@ -2,3 +2,4 @@ export FOO_BAR=1234
 BAZ = 5678
 # this is a comment
 BUZ: 9999
+QUX=0000 # this is another comment


### PR DESCRIPTION
This adds support for having a `#` comment which is made inline, separated from a variable's value by whitespace.

Use case: I'm fond of quickly testing environment changes by modifying the value but keeping the original as a comment at the end of the same line. For example, my .env file might contain something like this:

```
THIRD_PARTY_HOST=some.thirdparty.co.gov.edu.com
```

...but to get it to point to my own local version of that service, I'd modify it to look like this:

```
THIRD_PARTY_HOST=localhost:4000 # some.thirdparty.co.gov.edu.com
```

When I tried this in a project using dotenv_elixir, I found that the above `THIRD_PARTY_HOST` would have this as the value: "localhost:4000 " — note the space after the last 0.

This commit makes the "unquoted value" matcher (in `Dotenv`'s `@pattern` regex) non-greedy, so that the `\s*` in the trailing "optional comment" section picks up any trailing whitespace.
