### PR TITLE
Fix double/single quotes and add failing test cases for values with `#`

### DIFF
--- a/test/dotenv_test.exs
+++ b/test/dotenv_test.exs
@@ -15,6 +15,24 @@ defmodule DotenvTest do
     assert env["QUX"] == "0000"
   end
 
+  test "it parses values in double quotes" do
+    File.cd! proj1_dir
+    env = Dotenv.load
+    assert env["DOUBLE_QUOTED_VALUE"] == "NoDoubleQuotes"
+  end
+
+  test "it parses values that contain #" do
+    File.cd! proj1_dir
+    env = Dotenv.load
+    assert env["WITH_HASH"] == "foo#bar"
+  end
+
+  test "it parses values in single quotes" do
+    File.cd! proj1_dir
+    env = Dotenv.load
+    assert env["SINGLE_QUOTED_VALUE"] == "NoSingleQuotes"
+  end
+
   test "finding the dotenv from a subdir" do
     File.cd! Path.join(proj1_dir, "subdir")
     env = Dotenv.load

--- a/test/fixture/proj1/.env
+++ b/test/fixture/proj1/.env
@@ -3,3 +3,6 @@ BAZ = 5678
 # this is a comment
 BUZ: 9999
 QUX=0000 # this is another comment
+WITH_HASH=foo#bar
+DOUBLE_QUOTED_VALUE="NoDoubleQuotes"
+SINGLE_QUOTED_VALUE='NoSingleQuotes'


### PR DESCRIPTION
In the `@pattern` regex found in `lib/dotenv.ex` it mentions that it works with double and single quotes. But it also captures the quotes and not just the inside value.

I'm not sure what's wrong with the regex, but I thought I'd at least submit some failing specs to work against until there's time to figure out why it's not working.