### PR TITLE
relax elixir version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DotenvElixir.Mixfile do
   def project do
     [ app: :dotenv,
       version: "1.0.0",
-      elixir: "~> 1.0.0",
+      elixir: "~> 1.0",
       deps: deps,
       package: [
         contributors: ["Avdi Grimm", "David Rouchy", "Jared Norman", "Louis Simoneau"],


### PR DESCRIPTION
With Elixir 1.1 released, the current Elixir version requirements for the library give me a warning:
`warning: the dependency :dotenv requires Elixir "~> 1.0.0" but you are running on v1.1.0`

I don't think relaxing to 1.x would cause any issues?