### PR TITLE
Remove Access Protocol

### DIFF
--- a/lib/dotenv/env.ex
+++ b/lib/dotenv/env.ex
@@ -1,14 +1,13 @@
 defmodule Dotenv.Env do
   @type t :: %Dotenv.Env{paths: [String.t], values: %{String.t => String.t}}
-
   defstruct paths: [], values: HashDict.new
 
   def path(%Dotenv.Env{paths: paths}) do
     Enum.join(paths, ":")
   end
 
-  def get(%Dotenv.Env{values: values}, key) do
-    HashDict.get(values, key, nil)
+  def get(env, key) do
+    Dotenv.Env.get(env, System.get_env(key), key)
   end
 
   def get(%Dotenv.Env{values: values}, fallback, key) when is_function(fallback) do
@@ -18,12 +17,4 @@ defmodule Dotenv.Env do
   def get(%Dotenv.Env{values: values}, fallback, key) do
     HashDict.get(values, key, fallback)
   end
-end
-
-defimpl Access, for: Dotenv.Env do
-  def get(env, key) do
-    Dotenv.Env.get(env, System.get_env(key), key)
-  end
-
-  def get_and_update(env, _key, _fun), do: env
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule DotenvElixir.Mixfile do
   def project do
     [ app: :dotenv,
       version: "1.0.0",
-      elixir: "~> 1.0.0",
+      elixir: "~> 1.0",
       deps: deps,
       package: [
         contributors: ["Avdi Grimm", "David Rouchy", "Jared Norman", "Louis Simoneau"],

--- a/test/dotenv_test.exs
+++ b/test/dotenv_test.exs
@@ -9,32 +9,32 @@ defmodule DotenvTest do
     File.cd! proj1_dir
     env = Dotenv.load
     assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir)
-    assert env["FOO_BAR"] == "1234"
-    assert env["BAZ"] == "5678"
-    assert env["BUZ"] == "9999"
-    assert env["QUX"] == "0000"
+    assert Dotenv.Env.get(env, "FOO_BAR") == "1234"
+    assert Dotenv.Env.get(env, "BAZ") == "5678"
+    assert Dotenv.Env.get(env, "BUZ") == "9999"
+    assert Dotenv.Env.get(env, "QUX") == "0000"
   end
 
   test "it parses values in double quotes" do
     File.cd! proj1_dir
     env = Dotenv.load
-    assert env["DOUBLE_QUOTED_VALUE"] == "NoDoubleQuotes"
+    assert Dotenv.Env.get(env, "DOUBLE_QUOTED_VALUE") == "NoDoubleQuotes"
   end
 
   test "it parses values in single quotes" do
     File.cd! proj1_dir
     env = Dotenv.load
-    assert env["SINGLE_QUOTED_VALUE"] == "NoSingleQuotes"
+    assert Dotenv.Env.get(env, "SINGLE_QUOTED_VALUE") == "NoSingleQuotes"
   end
 
   test "finding the dotenv from a subdir" do
     File.cd! Path.join(proj1_dir, "subdir")
     env = Dotenv.load
     assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir)
-    assert env["FOO_BAR"] == "1234"
-    assert env["BAZ"] == "5678"
-    assert env["BUZ"] == "9999"
-    assert env["QUX"] == "0000"
+    assert Dotenv.Env.get(env, "FOO_BAR") == "1234"
+    assert Dotenv.Env.get(env, "BAZ") == "5678"
+    assert Dotenv.Env.get(env, "BUZ") == "9999"
+    assert Dotenv.Env.get(env, "QUX") == "0000"
   end
 
   test "loading into system environment" do
@@ -54,8 +54,8 @@ defmodule DotenvTest do
     env = Dotenv.load
     assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir)
     # .env values take precedence
-    assert env["FOO_BAR"] == "1234"
-    assert env["BAZZLE"]  == "4321"
+    assert Dotenv.Env.get(env, "FOO_BAR") == "1234"
+    assert Dotenv.Env.get(env, "BAZZLE") == "4321"
   end
 
   test "with explicit file" do


### PR DESCRIPTION
This will fix #22, but breaks the current API of dotenv, as `env[key]` would no longer exist.