### PR TITLE
Fix parse errors under several circumstances

### DIFF
--- a/test/dotenv_test.exs
+++ b/test/dotenv_test.exs
@@ -20,9 +20,10 @@ defmodule DotenvTest do
   test "parsing a simple dotenv file as found in the real world" do
     File.cd! proj3_dir
     env = Dotenv.load
+    assert Dotenv.Env.get(env, "EMPTY") == nil
     assert Dotenv.Env.path(env) == Path.expand(".env", proj3_dir)
     assert Dotenv.Env.get(env, "EXTERNAL_HOST") == "external.example.com"
-    assert Dotenv.Env.get(env, "INTERNAL_PROTOCOL") == "https"
+    assert Dotenv.Env.get(env, "EXTERNAL_PROTOCOL") == "https"
     assert Dotenv.Env.get(env, "INTERNAL_HOST") == "internal.example.com"
     assert Dotenv.Env.get(env, "INTERNAL_PROTOCOL") == "https"
   end

--- a/test/dotenv_test.exs
+++ b/test/dotenv_test.exs
@@ -4,6 +4,7 @@ defmodule DotenvTest do
   def fixture_dir, do: Path.expand("../fixture", __ENV__.file())
   def proj1_dir, do: Path.join(fixture_dir, "proj1")
   def proj2_dir, do: Path.join(fixture_dir, "proj2")
+  def proj3_dir, do: Path.join(fixture_dir, "proj3")
 
   test "parsing a simple dotenv file" do
     File.cd! proj1_dir
@@ -13,6 +14,17 @@ defmodule DotenvTest do
     assert Dotenv.Env.get(env, "BAZ") == "5678"
     assert Dotenv.Env.get(env, "BUZ") == "9999"
     assert Dotenv.Env.get(env, "QUX") == "0000"
+  end
+
+  @tag bug: true
+  test "parsing a simple dotenv file as found in the real world" do
+    File.cd! proj3_dir
+    env = Dotenv.load
+    assert Dotenv.Env.path(env) == Path.expand(".env", proj3_dir)
+    assert Dotenv.Env.get(env, "EXTERNAL_HOST") == "external.example.com"
+    assert Dotenv.Env.get(env, "INTERNAL_PROTOCOL") == "https"
+    assert Dotenv.Env.get(env, "INTERNAL_HOST") == "internal.example.com"
+    assert Dotenv.Env.get(env, "INTERNAL_PROTOCOL") == "https"
   end
 
   test "it parses values in double quotes" do

--- a/test/fixture/proj3/.env
+++ b/test/fixture/proj3/.env
@@ -1,0 +1,9 @@
+# This file is auto generated. Do not alter !!!
+# Source: Consul
+EMPTY=
+export EXTERNAL_HOST='external.example.com'
+export EXTERNAL_PORT=
+export EXTERNAL_PROTOCOL='https'
+export INTERNAL_HOST='internal.example.com'
+export INTERNAL_PORT=
+export INTERNAL_PROTOCOL='https'


### PR DESCRIPTION
This change updates the parser to be able to successfully
parse .env files that have mixed double and single quotes as well as no quotes.

Before that an .env file starting with a key value pair
where the value starts with single quotes would greedily
parse until the next occurence of another type of quotes.
That also happened when no quotes and any type of quotes would be mixed.

The regex for those values was too greedy.
In the course of this fix we also identified problems
with parsing of empty values. As a reaction to that
we switched to line based parsing which simplifies the
regex and makes the parsing process more tangible.

I know you wanted to maintain compatibility with the regex in the ruby version,
however that would require that oniguruma and the erlang regex engine
are compatible with regard to the expression that is used here. I'm no expert on this
but it doesn't seem to be the case.