### PR TITLE
Fix Elixir 1.4 warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Alternately, `load/1` will return a data structure of the variables read from th
 ```
 iex(1)> Dotenv.load
 %Dotenv.Env{paths: ["/elixir/dotenv_elixir/.env"],
- values: #HashDict<[{"APP_TEST_VAR", "HELLO"}]>}
+ values: %{"APP_TEST_VAR" => "HELLO"}}
 ```
 
 For further details, see the inline documentation. Usage examples can be found in [dotenv_test.exs](https://github.com/avdi/dotenv_elixir/blob/master/test/dotenv_test.exs).

--- a/lib/dotenv.ex
+++ b/lib/dotenv.ex
@@ -111,11 +111,11 @@ defmodule Dotenv do
     first_env = load(env_path)
     rest_env  = load(env_paths)
     %Env{paths:  [env_path|rest_env.paths],
-         values: Dict.merge(first_env.values, rest_env.values)}
+         values: Map.merge(first_env.values, rest_env.values)}
   end
 
   def load([]) do
-    %Env{paths: [], values: HashDict.new}
+    %Env{paths: [], values: Map.new}
   end
 
   def load(env_path) do
@@ -124,11 +124,11 @@ defmodule Dotenv do
     values = String.split(contents, "\n")
       |> Enum.flat_map(&Regex.scan(@pattern,&1))
       |> trim_quotes_from_values
-      |> Enum.reduce(HashDict.new, &collect_into_map/2)
+      |> Enum.reduce(Map.new, &collect_into_map/2)
       %Env{paths: [env_path], values: values}
   end
 
-  defp collect_into_map([_whole, k, v], env), do: HashDict.put(env, k, v)
+  defp collect_into_map([_whole, k, v], env), do: Map.put(env, k, v)
   defp collect_into_map([_whole, _k], env),   do: env
 
   defp trim_quotes_from_values(values) do
@@ -142,7 +142,7 @@ defmodule Dotenv do
   end
 
   defp read_env_file(:automatic) do
-    case find_env_path do
+    case find_env_path() do
       {:ok, env_path} -> {env_path, File.read!(env_path)}
       {:error, _}     -> {:none, ""}
     end

--- a/lib/dotenv/env.ex
+++ b/lib/dotenv/env.ex
@@ -1,6 +1,6 @@
 defmodule Dotenv.Env do
   @type t :: %Dotenv.Env{paths: [String.t], values: %{String.t => String.t}}
-  defstruct paths: [], values: HashDict.new
+  defstruct paths: [], values: Map.new
 
   def path(%Dotenv.Env{paths: paths}) do
     Enum.join(paths, ":")
@@ -11,10 +11,10 @@ defmodule Dotenv.Env do
   end
 
   def get(%Dotenv.Env{values: values}, fallback, key) when is_function(fallback) do
-    HashDict.get(values, key, fallback.(key))
+    Map.get(values, key, fallback.(key))
   end
 
   def get(%Dotenv.Env{values: values}, fallback, key) do
-    HashDict.get(values, key, fallback)
+    Map.get(values, key, fallback)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule DotenvElixir.Mixfile do
     [ app: :dotenv,
       version: "2.1.0",
       elixir: "~> 1.0",
-      deps: deps,
+      deps: deps(),
       package: [
         contributors: ["Avdi Grimm", "David Rouchy", "Jared Norman", "Louis Simoneau"],
         links: %{github: "https://github.com/avdi/dotenv_elixir"},

--- a/test/dotenv_app_test.exs
+++ b/test/dotenv_app_test.exs
@@ -2,11 +2,11 @@ defmodule DotenvAppTest do
   use ExUnit.Case
 
   def fixture_dir, do: Path.expand("../fixture", __ENV__.file())
-  def proj1_dir, do: Path.join(fixture_dir, "proj1")
+  def proj1_dir, do: Path.join(fixture_dir(), "proj1")
   def root_dir, do: Path.expand("../..", __ENV__.file())
 
   setup do
-    Dotenv.reload!(Path.join(root_dir, ".env"))
+    Dotenv.reload!(Path.join(root_dir(), ".env"))
     on_exit fn ->
       System.put_env "APP_TEST_VAR", ""
       System.put_env "FOO_BAR", ""
@@ -15,14 +15,14 @@ defmodule DotenvAppTest do
   end
 
   test "reloading from a new file" do
-    Dotenv.reload!(Path.join(proj1_dir, ".env"))
+    Dotenv.reload!(Path.join(proj1_dir(), ".env"))
     assert Dotenv.get("FOO_BAR") == "1234"
     assert System.get_env("FOO_BAR") == "1234"
   end
 
   test "fetching the whole environment" do
     env = Dotenv.env
-    assert Dict.get(env.values, "APP_TEST_VAR") == "HELLO"
+    assert Map.get(env.values, "APP_TEST_VAR") == "HELLO"
   end
 
   test "getting a value with a fallback" do

--- a/test/dotenv_test.exs
+++ b/test/dotenv_test.exs
@@ -2,14 +2,14 @@ defmodule DotenvTest do
   use ExUnit.Case, async: true
 
   def fixture_dir, do: Path.expand("../fixture", __ENV__.file())
-  def proj1_dir, do: Path.join(fixture_dir, "proj1")
-  def proj2_dir, do: Path.join(fixture_dir, "proj2")
-  def proj3_dir, do: Path.join(fixture_dir, "proj3")
+  def proj1_dir, do: Path.join(fixture_dir(), "proj1")
+  def proj2_dir, do: Path.join(fixture_dir(), "proj2")
+  def proj3_dir, do: Path.join(fixture_dir(), "proj3")
 
   test "parsing a simple dotenv file" do
-    File.cd! proj1_dir
+    File.cd! proj1_dir()
     env = Dotenv.load
-    assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir)
+    assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir())
     assert Dotenv.Env.get(env, "FOO_BAR") == "1234"
     assert Dotenv.Env.get(env, "BAZ") == "5678"
     assert Dotenv.Env.get(env, "BUZ") == "9999"
@@ -18,10 +18,10 @@ defmodule DotenvTest do
 
   @tag bug: true
   test "parsing a simple dotenv file as found in the real world" do
-    File.cd! proj3_dir
+    File.cd! proj3_dir()
     env = Dotenv.load
     assert Dotenv.Env.get(env, "EMPTY") == nil
-    assert Dotenv.Env.path(env) == Path.expand(".env", proj3_dir)
+    assert Dotenv.Env.path(env) == Path.expand(".env", proj3_dir())
     assert Dotenv.Env.get(env, "EXTERNAL_HOST") == "external.example.com"
     assert Dotenv.Env.get(env, "EXTERNAL_PROTOCOL") == "https"
     assert Dotenv.Env.get(env, "INTERNAL_HOST") == "internal.example.com"
@@ -29,21 +29,21 @@ defmodule DotenvTest do
   end
 
   test "it parses values in double quotes" do
-    File.cd! proj1_dir
+    File.cd! proj1_dir()
     env = Dotenv.load
     assert Dotenv.Env.get(env, "DOUBLE_QUOTED_VALUE") == "NoDoubleQuotes"
   end
 
   test "it parses values in single quotes" do
-    File.cd! proj1_dir
+    File.cd! proj1_dir()
     env = Dotenv.load
     assert Dotenv.Env.get(env, "SINGLE_QUOTED_VALUE") == "NoSingleQuotes"
   end
 
   test "finding the dotenv from a subdir" do
-    File.cd! Path.join(proj1_dir, "subdir")
+    File.cd! Path.join(proj1_dir(), "subdir")
     env = Dotenv.load
-    assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir)
+    assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir())
     assert Dotenv.Env.get(env, "FOO_BAR") == "1234"
     assert Dotenv.Env.get(env, "BAZ") == "5678"
     assert Dotenv.Env.get(env, "BUZ") == "9999"
@@ -52,7 +52,7 @@ defmodule DotenvTest do
 
   test "loading into system environment" do
     import System, only: [get_env: 1]
-    File.cd!(Path.join(proj1_dir, "subdir"))
+    File.cd!(Path.join(proj1_dir(), "subdir"))
     Dotenv.load!
     assert get_env("FOO_BAR") == "1234"
     assert get_env("BAZ")     == "5678"
@@ -61,25 +61,25 @@ defmodule DotenvTest do
   end
 
   test "falling back to system environment" do
-    File.cd! proj1_dir
+    File.cd! proj1_dir()
     System.put_env "FOO_BAR", "ORIGINAL_FOO_BAR"
     System.put_env "BAZZLE", "4321"
     env = Dotenv.load
-    assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir)
+    assert Dotenv.Env.path(env) == Path.expand(".env", proj1_dir())
     # .env values take precedence
     assert Dotenv.Env.get(env, "FOO_BAR") == "1234"
     assert Dotenv.Env.get(env, "BAZZLE") == "4321"
   end
 
   test "with explicit file" do
-    env_path = Path.join(proj2_dir, ".env")
+    env_path = Path.join(proj2_dir(), ".env")
     env = Dotenv.load!(env_path)
     assert Dotenv.Env.path(env) == env_path
     assert System.get_env("PROJ2_VAR") == "9876"
   end
 
   test "with multiple explicit files" do
-    env_paths = [Path.join(proj1_dir, ".env"), Path.join(proj2_dir, ".env")]
+    env_paths = [Path.join(proj1_dir(), ".env"), Path.join(proj2_dir(), ".env")]
     env = Dotenv.load!(env_paths)
     assert Dotenv.Env.path(env) == env_paths |> Enum.join(":")
     assert System.get_env("PROJ2_VAR") == "9876"


### PR DESCRIPTION
Dict and HashDict has been deprectaed in favor of Map module since it is now supported natively by Erlang vm. Using barewords for function calls is also deprecated. Tests are passing for Elixir 1.4.1 and 1.3.4.