### PR TITLE
Adds @moduledoc and @doc blocks to functions, including ## Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,10 @@
 # Dotenv for Elixir [![Hex pm](http://img.shields.io/hexpm/v/dotenv.svg?style=flat)](https://hex.pm/packages/dotenv) ![.github/workflows/main.yaml](https://github.com/iloveitaly/dotenv_elixir/workflows/.github/workflows/main.yaml/badge.svg)
 
-
 This is a port of @bkeepers' [dotenv](https://github.com/bkeepers/dotenv) project to Elixir. You can read more about dotenv on that project's page. The short version is that it simplifies developing projects where configuration is stored in environment variables (e.g. projects intended to be deployed to Heroku).
 
-## WARNING: Not compatible with Elixir releases
+See the [dotenv documentation on hexdocs](https://hexdocs.pm/dotenv/api-reference.html) for more info.
 
-Elixir has an excellent configuration system and this dotenv implementation has
-a serious limitation in that it isn't available at compile time. It fits very
-poorly into a deployment setup using Elixir releases, distillery, or similar.
-
-Configuration management should be built around Elixir's existing configuration system. A good example is [Phoenix](http://www.phoenixframework.org/) which generates a
-project where the production config imports the "secrets" from a file stored
-outside of version control. Even if you're using this for development, the same
-approach could be taken.
-
-However, if you are using Heroku, Dokku, or another deployment process that does *not* use releases, read on!
-
-### Quick Start
+## Quick Start
 
 The simplest way to use Dotenv is with the included OTP application. This will automatically load variables from a `.env` file in the root of your project directory into the process environment when started.
 
@@ -44,26 +32,7 @@ Fetch your dependencies with `mix deps.get`.
 
 Now, when you load your app in a console with `iex -S mix`, your environment variables will be set automatically.
 
-#### Using Environment Variables in Configuration
-
-[Mix loads configuration before loading any application code.](https://github.com/elixir-lang/elixir/blob/52141f2a3fa69906397017883242948dd93d91b5/lib/mix/lib/mix/tasks/run.ex#L123) If you want to use `.env` variables in your application configuration, you'll need to load dotenv manually on application start and reload your application config:
-
-```elixir
-defmodule App.Application do
-  use Application
-
-  def start(_type, _args) do
-    unless Mix.env == :prod do
-      Dotenv.load
-      Mix.Task.run("loadconfig")
-    end
-
-    # ... the rest of your application startup
-  end
-end
-```
-
-#### Elixir 1.9 and older
+## Elixir 1.9 and older
 
 If you are running an old version of Elixir, you'll need to add the `:dotenv` application to your applications list when running in the `:dev` environment:
 
@@ -80,25 +49,3 @@ defp app_list(:dev), do: [:dotenv | app_list]
 defp app_list(_), do: app_list
 defp app_list, do: [...]
 ```
-
-#### Reloading the `.env` file
-
-The `Dotenv.reload!/0` function will reload the variables defined in the `.env` file.
-
-More examples of the server API usage can be found in [dotenv_app_test.exs](https://github.com/avdi/dotenv_elixir/blob/master/test/dotenv_app_test.exs).
-
-### Serverless API
-
-If you would like finer-grained control over when variables are loaded, or would like to inspect them, Dotenv also provides a serverless API for interacting with `.env` files.
-
-The `load!/1` function loads variables into the process environment, and can be passed a path or list of paths to read from.
-
-Alternately, `load/1` will return a data structure of the variables read from the `.env` file:
-
-```elixir
-iex(1)> Dotenv.load
-%Dotenv.Env{paths: ["/elixir/dotenv_elixir/.env"],
- values: %{"APP_TEST_VAR" => "HELLO"}}
-```
-
-For further details, see the inline documentation. Usage examples can be found in [dotenv_test.exs](https://github.com/avdi/dotenv_elixir/blob/master/test/dotenv_test.exs).

--- a/lib/dotenv.ex
+++ b/lib/dotenv.ex
@@ -62,8 +62,9 @@ defmodule Dotenv do
           # ... etc ...
       end
 
-  Alternatively, you may with to define a dedicated configuration file for each
-  environment, in which case, you `runtime.exs` might look like this:
+  Alternatively, you may wish to define a dedicated configuration file for each
+  environment (e.g. `.env.test`, etc.), in which case, you `runtime.exs` might
+  look like this:
 
       import Config
       Dotenv.load!(".env.\#{config_env()}")

--- a/lib/dotenv.ex
+++ b/lib/dotenv.ex
@@ -1,22 +1,80 @@
 defmodule Dotenv do
   @moduledoc """
-  This module implements both an OTP application API and a "serverless" API.
+  This is a port of @bkeepers' [dotenv](https://github.com/bkeepers/dotenv)
+  project to Elixir.  It supports comments and variable substitutions.
 
-  Server API
-  ==========
+  ## Background
 
-  Start the application with `start/2` On starting, it will automatically export
-  the environment variables in the default path (`.env`).
+  Because Elixir is a compiled language with runtime flexibility, configuration
+  can be more confusing than you might be used to.  With the release of Elixir
+  1.11 and its `runtime.exs` configuration file, it is now easier to follow the
+  methodology of the [12 Factor App](https://12factor.net/) and its
+  recommendation to store configuration details in the environment (for example,
+  in `.env` files).  This is especially important when `mix release` is used to
+  build executable artifacts that must run _without_ `Mix`.  Instead of making
+  one app, you can easily end up with _three_ mostly-but-not-exactly-identical
+  applications (for `dev`, `prod`, and `test` environments).  Besides the
+  problem of having untestable code (because in such a scenario, some code may
+  not exist in the `test` environment) it is a bewildering state of affairs!
 
-  The environment can then be reloaded with `reload!/0` or a specific path
-  or list of paths can be provided to `reload!/1`.
+  This package can help organize your configuration and make it easier to keep
+  configuration details in the environment.
 
-  Serverless API
-  ==============
+  ## Loading Config
 
-  To use the serverless API, you can either load the environment variables with
-  `load!` (again, optionally passing in a path or list of paths), or you
-  can retrieve the variables without exporting them using `load`.
+  There are two primary ways that configuration values can be loaded:
+
+  `load/1` parses variables and their values from one or more files and returns
+  them in a `%Dotenv.Env{}` struct.
+
+  `load!/1` performs the same parsing as `load/1`, but it includes a side effect
+  of putting these values into the environment via `System.put_env/1`
+
+
+      iex(1)> Dotenv.load()
+      %Dotenv.Env{paths: ["path/to/.env"], values: %{"APP_TEST_VAR" => "HELLO"}}
+
+  ## Usage Suggestion
+
+  In order to be compatible both with regular `mix` execution of your app and
+  with mix releases, a proper solution needs to load configuration _before_
+  your application starts.  As mentioned previously, some things in Elixir must
+  be configured at compile-time (e.g. modules with macros), but a lot of your
+  application can be configured at runtime.
+
+  Imagine a simple `.env` at the root of your application:
+
+      DB_URL=postgres://myuser:mypassw0rd@localhost/mydb
+
+  If you wish to hard-code configuration values in your `config/test.exs`, then
+  your `config/runtime.exs` can rely on the `Config.config_env/0` function to
+  load your `.env` file(s) only when running in other configuration environments
+  (e.g. `dev` or `prod`).
+
+      # runtime.exs
+      import Config
+
+      if config_env() != :test do
+        Dotenv.load!(".env")
+
+        config :yourapp,
+          db_url: System.fetch_env!("DB_URL"),
+          # ... etc ...
+      end
+
+  Alternatively, you may with to define a dedicated configuration file for each
+  environment, in which case, you `runtime.exs` might look like this:
+
+      import Config
+      Dotenv.load!(".env.\#{config_env()}")
+
+      config :yourapp,
+          db_url: System.fetch_env!("DB_URL"),
+          # ... etc ...
+
+
+  For further examples, see the usage examples in
+  [dotenv_test.exs](https://github.com/avdi/dotenv_elixir/blob/master/test/dotenv_test.exs).
   """
 
   use Application
@@ -63,7 +121,7 @@ defmodule Dotenv do
   ##############################################################################
 
   @doc """
-  Calls the server to reload the values in the `.env` file into the
+  Reloads the values from `.env` file into the
   system environment.
 
   This call is asynchronous (`cast`).
@@ -79,7 +137,7 @@ defmodule Dotenv do
 
   This call is asynchronous (`cast`).
   """
-  @spec reload!(any) :: :ok
+  @spec reload!(env_path :: any()) :: :ok
   def reload!(env_path) do
     :gen_server.cast(:dotenv, {:reload!, env_path})
   end
@@ -132,6 +190,8 @@ defmodule Dotenv do
   This will overwrite values in the system environment: subsequent calls to
   `System.get_env/2` will be affected.
   If the path is omitted, `:automatic` is assumed.
+
+  If you do not wish to overwrite system variables, use `load/1` instead.
 
   ## Examples
 

--- a/lib/dotenv/env.ex
+++ b/lib/dotenv/env.ex
@@ -1,15 +1,46 @@
 defmodule Dotenv.Env do
+  @moduledoc """
+  This struct stores the values gleaned from the `.env` files located at
+  the given paths.  Accessor functions are provided.
+  """
   @type t :: %Dotenv.Env{paths: [String.t()], values: %{String.t() => String.t()}}
   defstruct paths: [], values: Map.new()
 
+  @doc """
+  Reveals the path(s) used to populate the given `%Dotenv.Env{}`, returned as
+  a string.
+
+  ## Examples
+
+      iex> Dotenv.env() |> Dotenv.Env.path()
+      "automatic"
+  """
   def path(%Dotenv.Env{paths: paths}) do
     Enum.join(paths, ":")
   end
 
+  @doc """
+  Gets the value at the given `key` from the given `%Dotenv.Env{}`.
+  If the `key` is not defined in the `env` provided, `nil` is returned.
+  """
+  @spec get(env :: Dotenv.Env.t(), String.t()) :: any()
   def get(env, key) do
     Dotenv.Env.get(env, System.get_env(key), key)
   end
 
+  @doc """
+  Gets the value at the given `key` from the given `%Dotenv.Env{}`.
+  If the `key` is not defined in the `env` provided, the `fallback` will be
+  returned as a default value if the `fallback` is not a function.
+  If the `fallback` value is a function, it will only be evaluated if the
+  `key` is not present in the given `env`.
+
+  ## Examples
+
+      iex> env = Dotenv.env()
+      iex> Dotenv.Env.get(env, "default-value", "KEY_DOES_NOT_EXIST")
+      "default-value"
+  """
   def get(%Dotenv.Env{values: values}, fallback, key) when is_function(fallback) do
     Map.get(values, key, fallback.(key))
   end


### PR DESCRIPTION
The big takeaway here is that your package IS compatible with releases -- the documentation just needs to clarify that.

This PR attempts to add more documentation per https://github.com/avdi/dotenv_elixir/issues/39
- Adds `## Examples` sections to many functions
- Shows a usage example of how to set this up to be compatible with releases
- Removes confusing references to "serverless" -- despite invoking an unrelated technology, how values are stored (or even if they are stored at all) is an implementation detail, and not one that needs to be documented because it is "behind the interface".